### PR TITLE
Workaround a padding issue when start a schedule (crontab.scheduleJob…

### DIFF
--- a/lib/crontab.js
+++ b/lib/crontab.js
@@ -7,8 +7,11 @@ var delayedQueueIntervalId = null;
 
 var scheduleJob = function(cronTime, callback, args, context, repeating, previousIndex){
     if(repeating == null) repeating = true;
-    var interval = parser.parseExpressionSync(cronTime),
-        difference = interval.next() - (new Date()),
+    var interval = parser.parseExpressionSync(cronTime);
+    for(var i in interval._fields)
+        if(interval._fields[i].length == 0)
+            return -1;
+    var difference = interval.next() - (new Date()),
         timeout = null,
         scheduledJobIndex = previousIndex;
 


### PR DESCRIPTION
Workaround a padding issue when start a schedule (crontab.scheduleJob) with a wrong cron time string with the dependencies package cron-parser ~0.3.3, i.e. `* * * * */0`, `* * * */0 *`
